### PR TITLE
SE: Implement `size`, `mtime`, `pattern`, and `location` filters

### DIFF
--- a/sophie.config
+++ b/sophie.config
@@ -1,5 +1,5 @@
 filecabinet
-	sophie_program[pattern="./sophie\.sh"; size="+1k";]
+	sophie_program[pattern="./sophie\.sh"; size="+1k"; mtime="-1h";]
 
 notices
 	ma-ilsi[literal="Copyright ma-ilsi";]

--- a/sophie.config
+++ b/sophie.config
@@ -2,7 +2,7 @@ filecabinet
 	sophie_program[pattern="./sophie\.sh"; size="+1k"; mtime="-1h";]
 
 notices
-	ma-ilsi[literal="Copyright ma-ilsi";]
+	ma-ilsi[pattern="Copyright ma-ilsi.*";]
 
 compliance
 	ma-ilsi_ip["ma-ilsi in sophie_program";]

--- a/sophie.config
+++ b/sophie.config
@@ -1,8 +1,8 @@
 filecabinet
-	sophie_program[pattern="./sophie\.sh";]
+	sophie_program[pattern="./sophie\.sh"; size="+1k";]
 
 notices
 	ma-ilsi[literal="Copyright ma-ilsi";]
 
 compliance
-	mailsi_ip["ma-ilsi in sophie_program";]
+	ma-ilsi_ip["ma-ilsi in sophie_program";]

--- a/sophie.config
+++ b/sophie.config
@@ -1,5 +1,5 @@
 filecabinet
-	sophie_program[pattern="./sophie\.sh"; size="+1k"; mtime="-1h";]
+	sophie_program[pattern="./sophie\.sh"; size="+1k";]
 
 notices
 	ma-ilsi[pattern="Copyright ma-ilsi.*"; location="1,4";]

--- a/sophie.config
+++ b/sophie.config
@@ -2,7 +2,7 @@ filecabinet
 	sophie_program[pattern="./sophie\.sh"; size="+1k"; mtime="-1h";]
 
 notices
-	ma-ilsi[pattern="Copyright ma-ilsi.*";]
+	ma-ilsi[pattern="Copyright ma-ilsi.*"; location="1,4";]
 
 compliance
 	ma-ilsi_ip["ma-ilsi in sophie_program";]

--- a/sophie.sh
+++ b/sophie.sh
@@ -28,6 +28,9 @@ filter=""
 #Value of filter to filter files using
 condition=""
 
+#Index used for keeping place in strings that are passed to `cut(1)`
+cut_count=0
+
 
 # -- File Cabinet -- #
 
@@ -101,7 +104,7 @@ while read line; do
 			#Identifier
 			cut_count=`expr "$line" : "[^\[]*\["`
 			curr_identifier=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/[[:space:]]*\[$//"`
-			(( ++cut_count ))
+			((cut_count+=1))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			#TODO: refinements are detected as second time requests to alter this identifier and a marker to indicate a refinement is placed.
@@ -114,13 +117,13 @@ while read line; do
 				#Filter
 				cut_count=`expr "$line" : "[^=]*=\""`
 				filter=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/=\"//"`
-				(( ++cut_count ))
+				((cut_count+=1))
 				line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 				#Filter condition
 				cut_count=`expr "$line" : "[^\<\";\>]*\";"`
 				condition=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/\";//"`
-				(( ++cut_count ))
+				((cut_count+=1))
 				line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 				#Fetching current command that represents matching files
@@ -193,7 +196,7 @@ while read line; do
 			#Identifier
 			cut_count=`expr "$line" : ".*\["`
 			curr_identifier=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/[[:space:]]*\[$//"`
-			(( ++cut_count ))
+			((cut_count+=1))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			while [ "$line" != "]" ]; do
@@ -204,13 +207,13 @@ while read line; do
 				#Filter
 				cut_count=`expr "$line" : "[^=]*=\""`
 				filter=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/=\"//"`
-				(( ++cut_count ))
+				((cut_count+=1))
 				line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 				#Filter condition
 				cut_count=`expr "$line" : "[^\<\";\>]*\";"`
 				condition=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/\";//"`
-				(( ++cut_count ))
+				((cut_count+=1))
 				line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 				#Apply filter after fetching old filter condition
@@ -281,24 +284,24 @@ while read line; do
 			#Identifier
 			cut_count=`expr "$line" : ".*\["`
 			curr_identifier=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/[[:space:]]*\[$//"`
-			(( cut_count += 2 ))
+			((cut_count+=2))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			compliance_identifier=$curr_identifier
 
 			cut_count=`expr "$line" : "[^ ]*"`
 			compliance_notice_identifier=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/ //"`
-			(( ++cut_count ))
+			((cut_count+=1))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			cut_count=`expr "$line" : ".* "`
 			compliance_preposition=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/ //"`
-			(( ++cut_count ))
+			((cut_count+=1))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			cut_count=`expr "$line" : ".*[^\\]\";"`
 			compliance_files_identifier=`printf "%s" "$line" | cut -c1-"$cut_count" | sed "s/\";//"`
-			(( ++cut_count ))
+			((cut_count+=1))
 			line=`printf "%s" "$line" | cut -c"$cut_count"-`
 
 			if [ -n "$compliance_files_identifier" ]; then

--- a/sophie.sh
+++ b/sophie.sh
@@ -163,6 +163,20 @@ while read line; do
 					filter="" 
 
 				fi
+
+				if [ "$filter" = "mtime" ]; then
+
+					new_files=`printf "%s%s%s" "$old_files" " __SOPHIE_MARKER " "-mtime $condition"`
+
+					#Remove old
+					file_cabinet=`printf "%s" "$file_cabinet" | sed "s/__SOPHIE_IDENTIFIER$curr_identifier=.*//"`
+					#Put new
+					file_cabinet=`printf "%s\n%s" "$file_cabinet" "__SOPHIE_IDENTIFIER$curr_identifier=$new_files"`
+
+					#This filter is done
+					filter="" 
+
+				fi
 				
 			done
 

--- a/sophie.sh
+++ b/sophie.sh
@@ -241,13 +241,21 @@ while read line; do
 
 				fi
 
+				#The `literal` filter is mutually excl. with `pattern`. Must not use both in a definition.
 
-				#if [ "$filter" = "pattern" ]; then
+				if [ "$filter" = "pattern" ]; then
 
-					#TODO
+					new_notice=`printf "%s%s%s" "$old_notice" " __SOPHIE_MARKER " "\"$condition\""`
 
-				#fi
+					#Remove old
+					notices=`printf "%s" "$notices" | sed "s/__SOPHIE_IDENTIFIER$curr_identifier=.*//"`
+					#Put new
+					notices=`printf "%s\n%s" "$notices" "__SOPHIE_IDENTIFIER$curr_identifier=$new_notice"`
 
+					#This filter is done
+					filter=""
+
+				fi
 
 				#if [ "$filter" = "location" ]; then
 


### PR DESCRIPTION
## Summary of Changes
As part of *Road to V1...*

Implements multi-filters following the descriptions of #1.

- `size` filter for `filecabinet`. Accepts file size argument mirroring the `-size` flag of `find(1)`.
- `mtime` filter for `filecabinet`. Accepts modification condition mirroring the `-mtime` flag of `find(1)`.
The conditions adopt `+` and `-` range specifiers from`find(1)`.

- `pattern` filter for `notices`. Accepts regex pattern.
- `location` filter for `notices`. Accepts `sed(1)`-based addresses. 

## Resolved Issues
Resolves #1 

## Testing
Local testing on this repo only. Need to automate testing.

The `location` filter addresses have only been tested for line number addresses. In reality, any valid `sed(1)` address should be a valid address for us, too.